### PR TITLE
Fix CI on TruffleRuby

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          bundler: latest
       - name: Install libsqlite3
         run: |
           sudo apt update -y && \


### PR DESCRIPTION
Changes:
- always use the latest bundler to have fixed TruffleRuby-related issues

A bundler version shipped with TruffleRuby (2.5.16) has a bug in handling platform specific gems. In case of TruffleRuby JRuby specific gems are installed. This bug was fixed in further bundler versions. So updating  the `bundler` gem resolves the issue on TruffleRuby.

Example of a failure on CI:

```
Ronin::Vulns::Importer.importer when given an Ronin::Vulns::ReflectedXSS object when #form_param is set on the vuln object must set the #form_param field to the vuln object's #form_param value
      Failure/Error: Ronin::DB.connect({adapter: :sqlite3, database: ':memory:'})

      NameError:
        uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger
      Shared Example Group: "importing common attributes" called from ./spec/importer_spec.rb:291
      # ./vendor/bundle/truffleruby/3.2.4.24.1.0.1/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:12:in `const_missing'
      # ./vendor/bundle/truffleruby/3.2.4.24.1.0.1/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:12:in `<module:LoggerThreadSafeLevel>'
      # ./vendor/bundle/truffleruby/3.2.4.24.1.0.1/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:9:in `<module:ActiveSupport>'
      # ./vendor/bundle/truffleruby/3.2.4.24.1.0.1/gems/activesupport-7.0.8.7/lib/active_support/logger_thread_safe_level.rb:8:in `<top (required)>'
      # ./vendor/bundle/truffleruby/3.2.4.24.1.0.1/gems/activesupport-7.0.8.7/lib/active_support/logger_silence.rb:5:in `<top (required)>'
      # ./vendor/bundle/truffleruby/3.2.4.24.1.0.1/gems/activesupport-7.0.8.7/lib/active_support/logger.rb:3:in `<top (required)>'
      # ./vendor/bundle/truffleruby/3.2.4.24.1.0.1/gems/activesupport-7.0.8.7/lib/active_support.rb:29:in `<top (required)>'
      # ./vendor/bundle/truffleruby/3.2.4.24.1.0.1/gems/activerecord-7.0.8.7/lib/active_record.rb:26:in `<top (required)>'
      # ./vendor/bundle/truffleruby/3.2.4.24.1.0.1/gems/ronin-db-0.2.0/lib/ronin/db.rb:126:in `connect'
      # ./spec/importer_spec.rb:15:in `block (3 levels) in <top (required)>'
```

The failure is cased by a bug in Rails 7.0 that was fixed in all the maintained Rails versions but unfortunately Rails 7.0 is not maintained. But `activerecord` 7.0 is a dependency on JRuby :

```ruby
platform :jruby do
  # ...
  gem 'activerecord', '< 7.1.0'
end
```